### PR TITLE
Update config instructions for Bash and Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add following lines to `~/.bashrc` or `~/.zshrc`:
 BASE16_SHELL="$HOME/.config/base16-shell/"
 [ -n "$PS1" ] && \
     [ -s "$BASE16_SHELL/profile_helper.sh" ] && \
-        eval "$("$BASE16_SHELL/profile_helper.sh")"
+        source "$BASE16_SHELL/profile_helper.sh"
         
 base16_default
 ```


### PR DESCRIPTION
In commit 0dd4544 the code was changed such that the profile_helper.sh should be loaded with `source` rather than `eval`. This commit updates the docs to reflect that change.